### PR TITLE
Add missing CSS for ".overthrow" element

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,16 @@ overthrow.sidescroller( scrollerElements, {
 
 Lastly, you'll need some responsive CSS to make the sidescroller presentable and work properly.
 
-First, let's style the slides. A quick reset and float to start things off:
+First, setup the `.overthrow` element to overflow its container.
+
+``` css
+.overthrow-enabled .overthrow {
+      overflow: auto;
+      z-index: 0;
+}
+```
+
+Then, let's style the slides. A quick reset and float to start things off:
 
 ``` css
 .overthrow-enabled .sidescroll ul,


### PR DESCRIPTION
Struggled getting this to work for an hour. Realized that the CSS in the readme is incomplete, and was missing a line required for ".overthrow" which is included in the demo CSS.

Added this code into the readme so it's clearer. It'd be nice to have a CSS file that's separable from the demo in the "/dist" folder, but not sure if that violates how you want this organized.
